### PR TITLE
Add Docker development documentation.

### DIFF
--- a/content/en/docs/usage/docker-development.md
+++ b/content/en/docs/usage/docker-development.md
@@ -1,0 +1,42 @@
+---
+title: "Developing with Docker"
+draft: false
+weight: -20
+toc: true
+---
+
+# Prerequisites:
+- A local [Docker](https://docs.docker.com/engine/) environment.
+
+## Steps
+
+1. Clone the repository locally.
+2. Enter the ourchive directory: `cd ourchive_app`.
+3. Run `docker compose up -d` to bring up containers.
+4. Load the fixtures: `docker compose run --rm web ./load-fixtures.sh`
+5. Create a superuser:
+	a. Run `docker compose exec -it web /bin/bash`
+	b. Run `python manage.py createsuperuser`
+6. Visit `http://localhost:8000`. Verify that it works!
+
+You should now be able to make modifications to your local files, and the development server should reflect those changes (though it may take a few seconds for the server to reload).
+
+## Debugging
+
+### View Logs
+
+Run `docker compose logs` for both DB and webserver logs.
+
+Run `docker compose logs web` for web logs.
+
+
+### Get a Docker Shell
+
+Run `docker compose exec -it web /bin/bash` to get a shell onto the docker container.
+
+Once there, you can run `manage.py` commands and other debugging tools.
+
+
+## Clear the Database
+
+You can delete the database by running `sudo rm -rf data` from the `ourchive_app` directory. Be sure you know what you're doing.

--- a/content/en/docs/usage/getting-started.md
+++ b/content/en/docs/usage/getting-started.md
@@ -18,6 +18,12 @@ If you are planning to install Ourchive as a website, please refer to the [admin
 <!--more-->
 
 
+# Local Development with Docker
+
+If you would like to do development with Docker containers, this is currently supported. Please visit [Developing with Docker]({{<ref "docker-development.md">}}).
+
+
+# Local Development Native
 
 ## Prerequisites
 
@@ -134,13 +140,7 @@ Ourchive ships with fixture data for some necessary configurations and for conve
 
 ```shell
 # load the fixture data
-python manage.py loaddata api/fixtures/ourchivesettings.yaml
-python manage.py loaddata api/fixtures/attributetype.yaml
-python manage.py loaddata api/fixtures/attributevalue.yaml
-python manage.py loaddata api/fixtures/notificationtype.yaml
-python manage.py loaddata api/fixtures/tagtype.yaml
-python manage.py loaddata api/fixtures/worktype.yaml
-python manage.py loaddata etl/fixtures/objectmapping.yaml
+./load-fixtures.sh
 ```
 
 ## Run migrations


### PR DESCRIPTION
Adds docker local development documentation and replaces the (incorrect) fixtures documentation with a call to the script that will update all fixtures.