### PR TITLE
Replace fixture loading steps with script.

### DIFF
--- a/content/en/docs/usage/getting-started.md
+++ b/content/en/docs/usage/getting-started.md
@@ -140,12 +140,7 @@ Ourchive ships with fixture data for some necessary configurations and for conve
 
 ```shell
 # load the fixture data
-python manage.py loaddata api/fixtures/ourchivesettings.yaml
-python manage.py loaddata api/fixtures/attributetype.yaml
-python manage.py loaddata api/fixtures/attributevalue.yaml
-python manage.py loaddata api/fixtures/notificationtypes.yaml
-python manage.py loaddata api/fixtures/tagtype.yaml
-python manage.py loaddata api/fixtures/worktype.yaml
+./load-fixtures.sh
 ```
 
 ## Run migrations


### PR DESCRIPTION
Putting the script reference back in so we don't have to maintain this list in two places.